### PR TITLE
Lock buttons when menu open

### DIFF
--- a/Client Source Code/Assets/Scripts/GameController.cs
+++ b/Client Source Code/Assets/Scripts/GameController.cs
@@ -606,16 +606,25 @@ public class GameController : MonoBehaviour {
         }
         else
         {
-            foreach (Transform child in optionsGroup.transform)
-            {
-                if (child.gameObject.activeSelf == true)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return isOptionsPanelOpen();
         }
+    }
+
+    /// <summary>
+    /// Checks whether the options menu is open.
+    /// </summary>
+    /// <returns>True if any panel of the options menu is open, false otherwise.</returns>
+    public bool isOptionsPanelOpen()
+    {
+        foreach (Transform child in optionsGroup.transform)
+        {
+            if (child.gameObject.activeSelf == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Client Source Code/Assets/Scripts/GameController.cs
+++ b/Client Source Code/Assets/Scripts/GameController.cs
@@ -42,6 +42,8 @@ public class GameController : MonoBehaviour {
 
     private float autoSaveTimer;
 
+    private OptionsController optionsController;
+
     // Use this for initialization
 	void Awake () {
         Debug.Log("Game controller is awake");
@@ -143,6 +145,8 @@ public class GameController : MonoBehaviour {
             Debug.Log("Started new game with seed " + startSeed);
             UnityEngine.Object.FindObjectOfType<FinishLoading>().ready();
         }
+
+        optionsController = optionsGroup.GetComponent<OptionsController>();
 	}
 	
 	// Update is called once per frame
@@ -606,25 +610,8 @@ public class GameController : MonoBehaviour {
         }
         else
         {
-            return isOptionsPanelOpen();
+            return optionsController.isOptionsPanelOpen();
         }
-    }
-
-    /// <summary>
-    /// Checks whether the options menu is open.
-    /// </summary>
-    /// <returns>True if any panel of the options menu is open, false otherwise.</returns>
-    public bool isOptionsPanelOpen()
-    {
-        foreach (Transform child in optionsGroup.transform)
-        {
-            if (child.gameObject.activeSelf == true)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/Client Source Code/Assets/Scripts/MapMenuController.cs
+++ b/Client Source Code/Assets/Scripts/MapMenuController.cs
@@ -31,12 +31,16 @@ public class MapMenuController : MonoBehaviour {
     private string remoteSavePath;
     private string remoteDataPath;
 
+    private OptionsController optionsController;
+
 	// Use this for initialization
 	void Start () {
         localSavePath = Application.persistentDataPath + "/localPlant.save";
         localRegionPath = Application.persistentDataPath + "/localregion";
         remoteSavePath = Application.persistentDataPath + "/remotePlant.save";
         remoteDataPath = Application.persistentDataPath + "/remotedata";
+
+        optionsController = FindObjectOfType<OptionsController>();
 	}
 	
 	// Update is called once per frame
@@ -52,8 +56,11 @@ public class MapMenuController : MonoBehaviour {
     /// </summary>
     public void back()
     {
-        //Application.LoadLevel("Main");
-        UnityEngine.Object.FindObjectOfType<SceneManager>().loadMain();
+        if (optionsController.isOptionsPanelOpen() == false)
+        {
+            //Application.LoadLevel("Main");
+            UnityEngine.Object.FindObjectOfType<SceneManager>().loadMain();
+        }
     }
 
     /// <summary>

--- a/Client Source Code/Assets/Scripts/MenuController.cs
+++ b/Client Source Code/Assets/Scripts/MenuController.cs
@@ -5,10 +5,12 @@ public class MenuController : MonoBehaviour {
     public string targetAccessory;
 
     private GameController gameController;
+    private OptionsController optionsController;
 
 	// Use this for initialization
 	void Start () {
         gameController = Object.FindObjectOfType<GameController>();
+        optionsController = Object.FindObjectOfType<OptionsController>();
 	}
 	
 	// Update is called once per frame
@@ -93,7 +95,7 @@ public class MenuController : MonoBehaviour {
     /// </summary>
     public void openMap()
     {
-        if (gameController.isOptionsPanelOpen() == false)
+        if (optionsController.isOptionsPanelOpen() == false)
         {
             save();
             Object.Destroy(Object.FindObjectOfType<GameController>().gameObject);

--- a/Client Source Code/Assets/Scripts/MenuController.cs
+++ b/Client Source Code/Assets/Scripts/MenuController.cs
@@ -5,12 +5,10 @@ public class MenuController : MonoBehaviour {
     public string targetAccessory;
 
     private GameController gameController;
-    private OptionsController optionsController;
 
 	// Use this for initialization
 	void Start () {
         gameController = Object.FindObjectOfType<GameController>();
-        optionsController = Object.FindObjectOfType<OptionsController>();
 	}
 	
 	// Update is called once per frame
@@ -95,7 +93,7 @@ public class MenuController : MonoBehaviour {
     /// </summary>
     public void openMap()
     {
-        if (optionsController.isOptionsPanelOpen() == false)
+        if (Object.FindObjectOfType<OptionsController>().isOptionsPanelOpen() == false)
         {
             save();
             Object.Destroy(Object.FindObjectOfType<GameController>().gameObject);

--- a/Client Source Code/Assets/Scripts/MenuController.cs
+++ b/Client Source Code/Assets/Scripts/MenuController.cs
@@ -4,11 +4,9 @@ using System.Collections;
 public class MenuController : MonoBehaviour {
     public string targetAccessory;
 
-    private GameController gameController;
-
 	// Use this for initialization
 	void Start () {
-        gameController = Object.FindObjectOfType<GameController>();
+        
 	}
 	
 	// Update is called once per frame

--- a/Client Source Code/Assets/Scripts/MenuController.cs
+++ b/Client Source Code/Assets/Scripts/MenuController.cs
@@ -4,9 +4,11 @@ using System.Collections;
 public class MenuController : MonoBehaviour {
     public string targetAccessory;
 
+    private GameController gameController;
+
 	// Use this for initialization
 	void Start () {
-	
+        gameController = Object.FindObjectOfType<GameController>();
 	}
 	
 	// Update is called once per frame
@@ -91,10 +93,13 @@ public class MenuController : MonoBehaviour {
     /// </summary>
     public void openMap()
     {
-        save();
-        Object.Destroy(Object.FindObjectOfType<GameController>().gameObject);
-        //Application.LoadLevel("Map");
-        Object.FindObjectOfType<SceneManager>().loadLevel("Map");
+        if (gameController.isOptionsPanelOpen() == false)
+        {
+            save();
+            Object.Destroy(Object.FindObjectOfType<GameController>().gameObject);
+            //Application.LoadLevel("Map");
+            Object.FindObjectOfType<SceneManager>().loadLevel("Map");
+        }
     }
 
     /// <summary>

--- a/Client Source Code/Assets/Scripts/OptionsController.cs
+++ b/Client Source Code/Assets/Scripts/OptionsController.cs
@@ -61,4 +61,17 @@ public class OptionsController : MonoBehaviour {
     {
         Object.FindObjectOfType<MusicController>().playSoundEffect(clip);
     }
+
+    public bool isOptionsPanelOpen()
+    {
+        foreach (Transform child in transform)
+        {
+            if (child.gameObject.activeSelf == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Previously the 'open map' and 'return to game' buttons in the game scene and map scene respectively would still function even if the options menu was currently open. Now, the buttons will only operate if the options menu is closed when they are pressed, to prevent accidentally changing scene while using the menu.
